### PR TITLE
Added build_arch for yggdrasil

### DIFF
--- a/ansible/roles/build-yggdrasil-rpm/defaults/main.yaml
+++ b/ansible/roles/build-yggdrasil-rpm/defaults/main.yaml
@@ -1,3 +1,4 @@
 ---
 base_repo_dir: /workspace/workspace
 rpm_build_directory: ~/rpmbuild
+build_arch: x86_64


### PR DESCRIPTION
Adds back the variable `build_arch` for building `Yggdrasil`. This variable was removed by mistake.

@ygalblum can you help to review this PR?