### PR TITLE
Changed tools default branch to main

### DIFF
--- a/helm/rpm-builder/values.yaml
+++ b/helm/rpm-builder/values.yaml
@@ -24,5 +24,5 @@ source:
     repoURL: https://github.com/jakub-dzon/k4e-device-worker.git
 
   tools:
-    branch: helm
+    branch: main
     repoURL: https://github.com/project-flotta/rfe-ansible-playbooks.git


### PR DESCRIPTION
Changed default tools branch from `helm` (development) to `main` (stable).

@pkliczewski  can you take a look? 