### PR TITLE
Changes to match the new home for k4e (flotta project)

### DIFF
--- a/ansible/playbooks/build-rpm.yaml
+++ b/ansible/playbooks/build-rpm.yaml
@@ -12,7 +12,7 @@
         paths: "{{ rpm_build_directory }}/RPMS/"
         patterns: 
           - '^yggdrasil-.*\.rpm$'
-          - '^k4e-agent-.*\.rpm$'
+          - '^flotta-agent-.*\.rpm$'
         use_regex: yes
         recurse: yes
       register: rpm_files

--- a/ansible/roles/build-device-worker/tasks/main.yaml
+++ b/ansible/roles/build-device-worker/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Assert RPMs created
   ansible.builtin.find:
     paths: "{{ rpm_build_directory }}/RPMS/"
-    patterns: '^k4e-agent-.*\.rpm$'
+    patterns: '^flotta-agent-.*\.rpm$'
     use_regex: yes
     recurse: yes
   register: agent_rpm

--- a/helm/rpm-builder/values.yaml
+++ b/helm/rpm-builder/values.yaml
@@ -21,7 +21,7 @@ source:
 
   worker:
     branch: main
-    repoURL: https://github.com/jakub-dzon/k4e-device-worker.git
+    repoURL: https://github.com/project-flotta/flotta-device-worker.git
 
   tools:
     branch: main


### PR DESCRIPTION
* Renamed references of the RPM names in the agent to flotta prefix
* Changed git project reference to project-flotta/flotta-device-worker repository

@pkliczewski @masayag @eloycoto @jakub-dzon please take a look at your convenience.