### PR TITLE
Add cpu arch to rpm upload path

### DIFF
--- a/ansible/playbooks/build-rpm.yaml
+++ b/ansible/playbooks/build-rpm.yaml
@@ -25,4 +25,5 @@
       vars:
         file_to_upload: "{{ item.path }}"
         nexus_repository: "{{ nexus_rpm_repository }}"
+        nexus_repository_folder: "{{ 'aarch64' if item.path | basename | regex_search('.aarch64.rpm$') else 'x86_64' if item.path | basename | regex_search('.x86_64.rpm$')}}"
       loop: "{{ rpm_files.files }}"    


### PR DESCRIPTION
This change relocates the RPMs based on their CPU architecture, rather than having them all in the same directory. The changes goes along with the source definition at bootstrap time:

```bash
"http://nexus:8081/repository/flotta-repo/$basearch"
```

@masayag @machacekondra @jakub-dzon @eloycoto  can you take a look? 
